### PR TITLE
Fixes travis trying to install a travis package from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - unzip protoc-3.0.0-linux-x86_64.zip -d protoc_dir
   - export PATH=$PATH:$PWD/protoc_dir/bin
   - export PATH=$HOME/.local/bin:$PATH
-  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl --user `whoami`
+  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl
   - pip install google-api-python-client pyyaml python-dateutil NewlineJSON
 
 script:


### PR DESCRIPTION
For some reason, this used to work because there was a pip package
called travis in there. They seem to have removed it now, and so `pip
install travis` breaks now. The `--user whoami` think ended up
generating a `travis` package, ignoring the `--user` part.