### PR TITLE
experiment with removing features

### DIFF
--- a/classification/classification/models/prod/layers.py
+++ b/classification/classification/models/prod/layers.py
@@ -136,7 +136,7 @@ def misconception_model(input,
                 # Don't use batch norm on last layer, just use dropout.
                 onet = slim.conv2d(onet, sub_count, [1, 1], normalizer_fn=None)
                 # Global average pool
-                n = int(onet.get_shape().dims[1])
+                n = int(onet.get_shape().dims[2])
                 onet = slim.avg_pool2d(onet, [1, n], stride=[1, n])
                 onet = slim.flatten(onet)
                 #

--- a/classification/classification/models/prod/vessel_characterization_achronic.py
+++ b/classification/classification/models/prod/vessel_characterization_achronic.py
@@ -102,7 +102,8 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        # Use season rather than day of year (sin(lat) * sin/cos(day or year))
+        features = tf.concat([features[:, :, :, 1:7], features[:, :, :, 10:]], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,

--- a/classification/classification/models/prod/vessel_characterization_achronic2.py
+++ b/classification/classification/models/prod/vessel_characterization_achronic2.py
@@ -102,7 +102,8 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        # Use season rather than day of year (sin(lat) * sin/cos(day or year))
+        features = tf.concat([features[:, :, :, 1:5], features[:, :, :, 10:14], features[:, :, :, 15:]], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,

--- a/classification/classification/models/prod/vessel_characterization_achronic3.py
+++ b/classification/classification/models/prod/vessel_characterization_achronic3.py
@@ -102,7 +102,7 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        features = tf.concat([features[:, :, :, 2:5], features[:, :, :, 10:14], features[:, :, :, 15:]], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,

--- a/classification/classification/models/prod/vessel_characterization_aseasonal.py
+++ b/classification/classification/models/prod/vessel_characterization_aseasonal.py
@@ -102,7 +102,8 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        # Use season rather than day of year (sin(lat) * sin/cos(day or year))
+        features = tf.concat([features[:, :, :, :7], features[:, :, :, 10:]], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,

--- a/classification/classification/models/prod/vessel_characterization_seasonal.py
+++ b/classification/classification/models/prod/vessel_characterization_seasonal.py
@@ -102,7 +102,8 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        # Use season rather than day of year (sin(lat) * sin/cos(day or year))
+        features = tf.concat([features[:, :, :, :7], features[:, :, :, 9:10] * features[:, :, :, 7:9], features[:, :, :, 10:]], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,

--- a/classification/classification/models/prod/vessel_characterization_time_scaled_2.py
+++ b/classification/classification/models/prod/vessel_characterization_time_scaled_2.py
@@ -102,7 +102,25 @@ class Model(abstract_models.MisconceptionModel):
         ]
 
     def _build_model(self, features, timestamps, mmsis, is_training):
-        features = tf.concat([features[:, :, :, :9], tf.sign(features[:, :, :, 9:10]), features[:, :, :, 10:]], 3)
+        # Use season rather than day of year (sin(lat) * sin/cos(day or year))
+        features = tf.concat([features[:, :, :, :7], features[:, :, :, 9:10] * features[:, :, :, 7:9], features[:, :, :, 10:]], 3)
+        dt = tf.exp(features[:, :, :, :1]) - 1
+        features = features[:, :, :, 1:]
+        dt = slim.conv2d(
+                        dt,
+                        256, [1, 1],
+                        activation_fn=tf.nn.relu,
+                        normalizer_fn=slim.batch_norm,
+                        normalizer_params={'is_training': is_training})
+        dt = slim.conv2d(
+                        dt,
+                        2, [1, 1],
+                        activation_fn=tf.nn.relu,
+                        normalizer_fn=slim.batch_norm,
+                        normalizer_params={'is_training': is_training})        
+        features_0 = dt[:, :, :, :1] * features
+        features_1 = dt[:, :, :, 1:] * features
+        features = tf.concat([features, features_0, features_1], 3)
         outputs, _ = layers.misconception_model(
             features,
             self.window_size,


### PR DESCRIPTION
**DO NOT MERGE**

# Experiments to determine the relative importance of various features

* Using both month of year and latitude was problematic because it allowed overfitting
   by latitude. Two possible alternitives:

  - Use seasonality: `sin(lat) * cos(month)`, `sin(lat) * sin(month)` where month is expressed 
     in radians.

  - A-seasonal: don`t use month or lat.

  So far these seem to be about equally effective, so lean towards a-seasonal as simpler.

* How much does knowing time help? Not much it seems

   - Removing `dt` has very little effect.

   - Removing all time related stuff (achronic3) has a small (~2% effect) on classification accuracy.

  This is for vessel classification, perhaps this *very* overdetermined. It's possible that these
  effects may be larger for fishing detection. [UPDATE] Not obviously, so continue with classification

* What if we remove everything:

   - We get about 33% accuracy, presumably the fraction of cargo vessels in the data, but 
      I haven't checked that.

  - Interesting, if we just keep `dt` get about 43% accuracy, so just knowing the spacing in time 
    points is enough to help differentiate vessels!

* What about speed:

   - If we look at everything except speed (no reported speed, implied speed, or dx -- since
     speed can be computed from that), we get about 81% accuracy.

   - If we only look at speed related item ( reported speed, implied speed, and dx), we
      get about 80% accuracy.

So far the features seem to be highly redundant with no features dominating.
