### PR TITLE
Removes bad char present in install_requires of the setup.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v3.0.3 - 2023-07-19
+
+### Changed
+
+  * [PIPELINE-1407](https://globalfishingwatch.atlassian.net/browse/PIPELINE-1407): Changes
+    Removes the char `'` present in install_requirements. It fixes the issue at build:
+    'install_requires' must be a string or list of strings containing valid
+    project/version requirement specifiers.
+
 ## v3.0.2 - 2020-03-29
 
 ### Added

--- a/classification/__init__.py
+++ b/classification/__init__.py
@@ -2,12 +2,12 @@
 Vessel classification: feature generation and model training/inference.
 """
 
-__version__ = '3.0.2'
+__version__ = '3.0.3'
 __author__ = 'Tim Hochberg'
 __email__ = 'tim@globalfishingwatch.com'
 __source__ = 'https://github.com/GlobalFishingWatch/vessel-classification'
 __license__ = """
-Copyright 2020 Global Fishing Watch Inc.
+Copyright 2023 Global Fishing Watch Inc.
 Authors:
 
 Tim Hochberg <tim@globalfishingwatch.com>

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ package = __import__('classification')
 
 DEPENDENCIES = [
     "google-api-python-client",
-    "six>=1.13.0'"
+    "six>=1.13.0"
 ]
 
 


### PR DESCRIPTION
- Removes extra char in the property `install_requires` of the `setup.py` was reporting a build issue:
```
Collecting vessel-inference@ <https://codeload.github.com/GlobalFishingWatch/vessel-classification/tar.gz/v3.0.2>
  Downloading <https://codeload.github.com/GlobalFishingWatch/vessel-classification/tar.gz/v3.0.2>
     | 8.5 MB 235.4 kB/s 0:00:36
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in vessel_inference setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          six>=1.13.0'
             ~~~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```
And after fixing it, the test did:
```
root@29aeb4fbc541:/opt/project# python setup.py egg_info
running egg_info
writing vessel_inference.egg-info/PKG-INFO
writing dependency_links to vessel_inference.egg-info/dependency_links.txt
writing requirements to vessel_inference.egg-info/requires.txt
writing top-level names to vessel_inference.egg-info/top_level.txt
reading manifest file 'vessel_inference.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'vessel_inference.egg-info/SOURCES.txt'
```

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1407